### PR TITLE
Add allow-prereleases input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   cache-build:
     required: false
     description: Whether to cache the built Python distribution to speed up successive runs.
-    default: 'false'
+    default: false
   allow-build:
     required: false
     description: "Set the behavior of the actoin when actions/setup-python fails and has to build from source. Supported values: allow, info, warn, error"

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   token:
     description: "The token used to authenticate when fetching Python distributions from https://github.com/actions/python-versions. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting."
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+  allow-prereleases:
+    description: "When 'true', a version range passed to 'python-version' input will match prerelease versions if no GA versions are found. Only 'x.y' version range is supported for CPython."
+    default: false
 outputs:
   python-version:
     description: The parsed (and eventually built) python version

--- a/src/__tests__/__snapshots__/inputs.test.ts.snap
+++ b/src/__tests__/__snapshots__/inputs.test.ts.snap
@@ -18,6 +18,16 @@ exports[`Parsed inputs "allow-build" using allow-build" with value "ok" throws a
 
 exports[`Parsed inputs "allow-build" using allow-build" with value "yes" throws an Error 1`] = `"Unrecognized input value for "allow-build". Expected one of "allow", "info", "warn", "error". Got "yes"."`;
 
+exports[`Parsed inputs "allow-prereleases" empty "allow-prereleases" throws an Error 1`] = `"Expected boolean value for input "allow-prereleases". Supported values are "true", "false", "True", "False", "TRUE", "FALSE". Got ""."`;
+
+exports[`Parsed inputs "allow-prereleases" using "allow-prereleases" with value "0" throws an Error 1`] = `"Expected boolean value for input "allow-prereleases". Supported values are "true", "false", "True", "False", "TRUE", "FALSE". Got "0"."`;
+
+exports[`Parsed inputs "allow-prereleases" using "allow-prereleases" with value "1" throws an Error 1`] = `"Expected boolean value for input "allow-prereleases". Supported values are "true", "false", "True", "False", "TRUE", "FALSE". Got "1"."`;
+
+exports[`Parsed inputs "allow-prereleases" using "allow-prereleases" with value "FalSe" throws an Error 1`] = `"Expected boolean value for input "allow-prereleases". Supported values are "true", "false", "True", "False", "TRUE", "FALSE". Got "FalSe"."`;
+
+exports[`Parsed inputs "allow-prereleases" using "allow-prereleases" with value "TRue" throws an Error 1`] = `"Expected boolean value for input "allow-prereleases". Supported values are "true", "false", "True", "False", "TRUE", "FALSE". Got "TRue"."`;
+
 exports[`Parsed inputs "cache-build" empty "cache-build" throws an Error 1`] = `"Expected boolean value for input "cache-build". Supported values are "true", "false", "True", "False", "TRUE", "FALSE". Got ""."`;
 
 exports[`Parsed inputs "cache-build" using "cache-build" with value "0" throws an Error 1`] = `"Expected boolean value for input "cache-build". Supported values are "true", "false", "True", "False", "TRUE", "FALSE". Got "0"."`;

--- a/src/__tests__/inputs.fixtures.ts
+++ b/src/__tests__/inputs.fixtures.ts
@@ -82,6 +82,7 @@ export type MockedInputs = {
   allowBuild: string;
   token: string;
   checkLatest: string;
+  allowPrereleases: string;
 };
 
 export function mockInput(
@@ -104,6 +105,8 @@ export function mockInput(
     return inputs.token;
   } else if (input === InputNames.CHECK_LATEST) {
     return inputs.checkLatest;
+  } else if (input === InputNames.PRERELEASES) {
+    return inputs.allowPrereleases;
   } else {
     return '';
   }

--- a/src/__tests__/inputs.test.ts
+++ b/src/__tests__/inputs.test.ts
@@ -23,6 +23,7 @@ import {InputNames} from '../constants';
 
 const mockedInputs: MockedInputs = {
   allowBuild: 'warn',
+  allowPrereleases: 'false',
   architecture: 'x64',
   cacheBuild: 'false',
   checkLatest: 'false',
@@ -92,6 +93,7 @@ describe('Parsed inputs', () => {
     mockedInputs.pythonVersionFile = 'file';
     mockedInputs.token = 'token';
     mockedInputs.checkLatest = 'false';
+    mockedInputs.allowPrereleases = 'false';
   });
 
   describe(`"${InputNames.PYTHON_VERSION}" and "${InputNames.PYTHON_VERSION_FILE}"`, () => {
@@ -260,6 +262,47 @@ describe('Parsed inputs', () => {
 
     test(`empty "${InputNames.CHECK_LATEST}" throws an Error`, async () => {
       mockedInputs.checkLatest = '';
+
+      await expect(inputs.parseInputs()).rejects.toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe(`"${InputNames.PRERELEASES}"`, () => {
+    test.each(['false', 'FALSE', 'False'])(
+      `using "${InputNames.PRERELEASES}" with value "%s" leads to "false"`,
+      async latest => {
+        mockedInputs.allowPrereleases = latest;
+
+        const parsedInputs = await inputs.parseInputs();
+
+        expect(parsedInputs.allowPrereleases).toBe(false);
+      }
+    );
+
+    test.each(['true', 'TRUE', 'True'])(
+      `using "${InputNames.PRERELEASES}" with value "%s" leads to "true"`,
+      async latest => {
+        mockedInputs.allowPrereleases = latest;
+
+        const parsedInputs = await inputs.parseInputs();
+
+        expect(parsedInputs.allowPrereleases).toBe(true);
+      }
+    );
+
+    test.each(['TRue', 'FalSe', '1', '0'])(
+      `using "${InputNames.PRERELEASES}" with value "%s" throws an Error`,
+      async latest => {
+        mockedInputs.allowPrereleases = latest;
+
+        await expect(
+          inputs.parseInputs()
+        ).rejects.toThrowErrorMatchingSnapshot();
+      }
+    );
+
+    test(`empty "${InputNames.PRERELEASES}" throws an Error`, async () => {
+      mockedInputs.allowPrereleases = '';
 
       await expect(inputs.parseInputs()).rejects.toThrowErrorMatchingSnapshot();
     });

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -68,6 +68,7 @@ describe('main', () => {
   describe('input parsing', () => {
     test('calls inputs.parseInputs', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: false,
@@ -101,6 +102,7 @@ describe('main', () => {
   describe('actions/setup-python result', () => {
     test('calls version.getSetupPythonResult', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: false,
@@ -120,6 +122,7 @@ describe('main', () => {
 
     test('handles a failure in version.getSetupPythonResult with CPython', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: false,
@@ -144,6 +147,7 @@ describe('main', () => {
 
     test('handles a failure in version.getSetupPythonResult with PyPy', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: false,
@@ -170,6 +174,7 @@ describe('main', () => {
     describe('CPython', () => {
       test('success', async () => {
         mockedInputs.parseInputs.mockResolvedValueOnce({
+          allowPrereleases: false,
           architecture: 'x64',
           buildBehavior: inputs.BuildBehavior.Info,
           cache: false,
@@ -205,6 +210,7 @@ describe('main', () => {
 
       test('failure', async () => {
         mockedInputs.parseInputs.mockResolvedValueOnce({
+          allowPrereleases: false,
           architecture: 'x64',
           buildBehavior: inputs.BuildBehavior.Info,
           cache: false,
@@ -237,6 +243,7 @@ describe('main', () => {
     describe('PyPy', () => {
       test('success', async () => {
         mockedInputs.parseInputs.mockResolvedValueOnce({
+          allowPrereleases: false,
           architecture: 'x64',
           buildBehavior: inputs.BuildBehavior.Info,
           cache: false,
@@ -272,6 +279,7 @@ describe('main', () => {
 
       test('failure', async () => {
         mockedInputs.parseInputs.mockResolvedValueOnce({
+          allowPrereleases: false,
           architecture: 'x64',
           buildBehavior: inputs.BuildBehavior.Info,
           cache: false,
@@ -309,6 +317,7 @@ describe('main', () => {
   describe('Build behaior', () => {
     test('Error leads to a failed action with an error message', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Error,
         cache: false,
@@ -331,6 +340,7 @@ describe('main', () => {
 
     test('Warn leads to building from source with a warning', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Warn,
         cache: false,
@@ -372,6 +382,7 @@ describe('main', () => {
 
     test('Info leads to building from source with a message in the logs', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: false,
@@ -415,6 +426,7 @@ describe('main', () => {
 
     test('Allow leads to building from source with a message in the debug logs', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Allow,
         cache: false,
@@ -460,6 +472,7 @@ describe('main', () => {
   describe('builder.getBuilder', () => {
     test('calls builder.getBuilder', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: false,
@@ -490,6 +503,7 @@ describe('main', () => {
 
     test('handles builder.getBuilder returning null', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: false,
@@ -516,6 +530,7 @@ describe('main', () => {
 
     test('fails to handle a failure in builder.getBuilder', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: false,
@@ -539,6 +554,7 @@ describe('main', () => {
   describe('Builder', () => {
     test('cache false leads to calling build, clean and postInstall on the builder', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: false,
@@ -582,6 +598,7 @@ describe('main', () => {
 
     test('cache-hit leads to calling restoreCache, postInstall and clean on the builder', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: true,
@@ -625,6 +642,7 @@ describe('main', () => {
 
     test('cache-miss leads to calling restoreCache, build, saveCache, postInstall and clean on the builder', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: true,
@@ -671,6 +689,7 @@ describe('main', () => {
 
     test('handles failure in restoreCache', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: true,
@@ -711,6 +730,7 @@ describe('main', () => {
 
     test('handles failure in build', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: true,
@@ -754,6 +774,7 @@ describe('main', () => {
 
     test('handles failure in saveCache', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: true,
@@ -797,6 +818,7 @@ describe('main', () => {
 
     test('handles failure in postInstall', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: true,
@@ -846,6 +868,7 @@ describe('main', () => {
 
     test('fails to handle failure in clean', async () => {
       mockedInputs.parseInputs.mockResolvedValueOnce({
+        allowPrereleases: false,
         architecture: 'x64',
         buildBehavior: inputs.BuildBehavior.Info,
         cache: true,

--- a/src/__tests__/version.fixtures.ts
+++ b/src/__tests__/version.fixtures.ts
@@ -82,6 +82,7 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
@@ -106,6 +107,7 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
@@ -130,6 +132,7 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
@@ -154,6 +157,7 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
@@ -178,6 +182,7 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
@@ -202,6 +207,7 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
@@ -226,6 +232,7 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
@@ -250,6 +257,7 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
@@ -274,6 +282,7 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
@@ -298,12 +307,113 @@ const SetupPythonTests: SetupPythonResultTest[] = [
       }
     },
     inputs: {
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: true,
       checkLatest: false,
       token: 'token',
       version: new PythonVersion('3')
+    }
+  },
+  {
+    expectedResult: {
+      darwin: {
+        success: true,
+        version: '3.12.0-alpha.3'
+      },
+      linux: {
+        success: true,
+        version: '3.12.0-alpha.3'
+      },
+      win32: {
+        success: true,
+        version: '3.12.0-alpha.3'
+      }
+    },
+    inputs: {
+      allowPrereleases: true,
+      architecture: process.arch,
+      buildBehavior: BuildBehavior.Info,
+      cache: true,
+      checkLatest: false,
+      token: 'token',
+      version: new PythonVersion('3.12')
+    }
+  },
+  {
+    expectedResult: {
+      darwin: {
+        success: false,
+        version: ''
+      },
+      linux: {
+        success: false,
+        version: ''
+      },
+      win32: {
+        success: false,
+        version: ''
+      }
+    },
+    inputs: {
+      allowPrereleases: true,
+      architecture: process.arch,
+      buildBehavior: BuildBehavior.Info,
+      cache: true,
+      checkLatest: false,
+      token: 'token',
+      version: new PythonVersion('3.12.0')
+    }
+  },
+  {
+    expectedResult: {
+      darwin: {
+        success: false,
+        version: ''
+      },
+      linux: {
+        success: false,
+        version: ''
+      },
+      win32: {
+        success: false,
+        version: ''
+      }
+    },
+    inputs: {
+      allowPrereleases: false,
+      architecture: process.arch,
+      buildBehavior: BuildBehavior.Info,
+      cache: true,
+      checkLatest: false,
+      token: 'token',
+      version: new PythonVersion('3.12')
+    }
+  },
+  {
+    expectedResult: {
+      darwin: {
+        success: false,
+        version: ''
+      },
+      linux: {
+        success: false,
+        version: ''
+      },
+      win32: {
+        success: false,
+        version: ''
+      }
+    },
+    inputs: {
+      allowPrereleases: true,
+      architecture: process.arch,
+      buildBehavior: BuildBehavior.Info,
+      cache: true,
+      checkLatest: false,
+      token: 'token',
+      version: new PythonVersion('3.13')
     }
   }
 ];

--- a/src/__tests__/version.test.ts
+++ b/src/__tests__/version.test.ts
@@ -87,6 +87,7 @@ describe(`getSetupPythonResult with manifest url ${manifestUrl}`, () => {
     };
 
     const result = await getSetupPythonResult({
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: false,
@@ -108,6 +109,7 @@ describe(`getSetupPythonResult with manifest url ${manifestUrl}`, () => {
     };
 
     const result = await getSetupPythonResult({
+      allowPrereleases: false,
       architecture: process.arch,
       buildBehavior: BuildBehavior.Info,
       cache: false,
@@ -120,7 +122,7 @@ describe(`getSetupPythonResult with manifest url ${manifestUrl}`, () => {
   });
 
   test.each(SetupPythonTests)(
-    `returns $expectedResult.${process.platform} for input version $inputs.version.type-$inputs.version.version and architecture $inputs.architecture`,
+    `returns $expectedResult.${process.platform} for input version $inputs.version.type-$inputs.version.version for $inputs.architecture and allow prereleases $inputs.allowPrereleases`,
     async ({expectedResult, inputs}) => {
       mockedTC.find.mockReturnValue('');
       let platformResult: SetupPythonResult;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,8 @@ export enum InputNames {
   CACHE_BUILD = 'cache-build',
   ALLOW_BUILD = 'allow-build',
   TOKEN = 'token',
-  CHECK_LATEST = 'check-latest'
+  CHECK_LATEST = 'check-latest',
+  PRERELEASES = 'allow-prereleases'
 }
 
 export enum OutputNames {

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -74,6 +74,7 @@ export type ActionInputs = {
   buildBehavior: BuildBehavior;
   token: string;
   checkLatest: boolean;
+  allowPrereleases: boolean;
 };
 
 async function getBehavior(): Promise<BuildBehavior> {
@@ -139,6 +140,21 @@ async function getCheckLatest(): Promise<boolean> {
   }
 }
 
+async function getAllowPrereleases(): Promise<boolean> {
+  core.debug('Parsing allow prereleases input');
+  try {
+    return core.getBooleanInput(InputNames.PRERELEASES);
+  } catch (error) {
+    throw new Error(
+      `Expected boolean value for input "${
+        InputNames.PRERELEASES
+      }". Supported values are "true", "false", "True", "False", "TRUE", "FALSE". Got "${core.getInput(
+        InputNames.PRERELEASES
+      )}".`
+    );
+  }
+}
+
 async function getArchitecture(): Promise<string> {
   const archString: string = core.getInput(InputNames.ARCHITECTURE);
   core.debug(`Parsing architecture string "${archString}"`);
@@ -190,6 +206,7 @@ async function extractPythonVersion(): Promise<string> {
 
 export async function parseInputs(): Promise<ActionInputs> {
   return {
+    allowPrereleases: await getAllowPrereleases(),
     architecture: await getArchitecture(),
     buildBehavior: await getBehavior(),
     cache: await getCache(),


### PR DESCRIPTION
Implements new features from [actions/setup-python v4.6.0](https://github.com/actions/setup-python/releases/tag/v4.6.0)